### PR TITLE
Updated module to be compatible with the new rewritten Fluency module.

### DIFF
--- a/ProcessTranslatePage.config.php
+++ b/ProcessTranslatePage.config.php
@@ -18,7 +18,7 @@ class ProcessTranslatePageConfig extends ModuleConfig {
 
     public function getDefaults() {
         return [
-            'sourceLanguage' => wire('languages')->get('default')->name,
+            'sourceLanguage' => wire('languages')->get('default')->id,
             'excludedTemplates' => [],
             'excludedFields' => [],
             'excludedLanguages' => [],
@@ -28,14 +28,13 @@ class ProcessTranslatePageConfig extends ModuleConfig {
     }
 
     private function getLanguageOptions() {
-        $processTranslatePage = wire('modules')->get('ProcessTranslatePage');
-        $availableLanguages = $processTranslatePage::getAvailableLanguages();
-        $languageOptions = [];
-        foreach ($availableLanguages as $language) {
-            $languageOptions[$language['page']->name] = (string) $language['page']->get('title|name');
-        }
+        $configuredLanguages = wire('modules')->get('Fluency')->getConfiguredLanguages()->languages;
 
-        return $languageOptions;
+        return array_reduce($configuredLanguages, function($options, $language) {
+            $options[$language->id] = $language->title;
+
+            return $options;
+        }, []);
     }
 
     private function getTemplateOptions() {

--- a/ProcessTranslatePage.info.php
+++ b/ProcessTranslatePage.info.php
@@ -3,11 +3,11 @@
 $info = array(
 	'title' => 'TranslatePage (via Fluency)',
 	'summary' => 'Translates all textfields on a page via Fluency',
-	'version' => 8,
+	'version' => 9,
 	'author' => 'Robert Weiss',
 	'icon' => 'language',
     'requires' => [
-        'Fluency',
+        'Fluency>=1.0.6',
         'ProcessWire>=3.0.184'
     ],
 	'href' => 'https://github.com/robertweiss/ProcessTranslatePage',


### PR DESCRIPTION
Refactored to work with the new Fluency module's API.

- Module and config both use Fluency to provide the languages that are configured
- Module config stores the ProcessWire language IDs as config values for default/excluded languages
- Source/Target languages are now instances of Fluency's `ConfiguredLanguageData` objects that encapsulate much of the data needed
- Using the `ConfiguredLanguageData` object removed the need to manually parse language codes or determine which should be used
- Add error handling. Fluency's `translate` method returns localized error messages that will now be shown after page load if problems occurred during translation
- Fixed a bug where excluded languages were still included
- Versioned the Fluency module dependency to require Fluency 1.0.6 or later
- Version bump, incompatible with previous versions of Fluency

Items that don't affect functionality:

- The info banner after page save now shows which fields were translated by name, ended up helping during coding
- Messages and strings in the UI for ProcessTranslatePage uses the localized strings from Fluency so this module will be automatically translated if Fluency has been

I ended up having to make some modifications to how Fluency initializes itself so that it can be used by other modules, so users will need to upgrade Fluency to the latest for these modules to work together.